### PR TITLE
feat(options): add small rounded corners option

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -325,13 +325,15 @@ int main() try
                        "fallback method by default in case the .rdata method fails."sv},
       Option{L"verbose"sv, L"Enables verbose output."sv},
       Option{L"disable"sv, L"Always disables rounded corners. Has precedence over --enable."sv},
-      Option{L"enable"sv, L"Always enables rounded corners."sv}
+      Option{L"enable"sv, L"Always enables rounded corners."sv},
+      Option{L"small"sv, L"Enables small rounded corners."sv}
   };
 
   set_verbose(options[L"verbose"sv].value);
   
   auto should_disable = options[L"disable"sv].value;
-  auto const should_override_toggle = should_disable || options[L"enable"sv].value;
+  auto const should_override_toggle = should_disable || options[L"enable"sv].value || options[L"small"sv].value;
+  const bool should_small = options[L"small"sv].value;
 
   if (!enable_privilege(SE_DEBUG_NAME))
     throw std::runtime_error(std::format("Failed to enable '{}', make sure you are running as admin.", SE_DEBUG_NAME));
@@ -407,6 +409,7 @@ int main() try
                                       return std::make_tuple(flt, rebased);
                                     })) {
       constexpr auto kNearZeroRadius = 0.001f;
+      constexpr auto kSmallRadius = 4.0f;
       float value{};
       SIZE_T out_size{};
 
@@ -417,7 +420,14 @@ int main() try
       if (!should_override_toggle)
         should_disable = !is_disabled;
 
-      auto const new_border_radius = should_disable ? kNearZeroRadius : original;
+      float new_border_radius;
+      if (should_disable)
+        new_border_radius = kNearZeroRadius;
+      else if (should_small)
+        new_border_radius = kSmallRadius;
+      else
+        new_border_radius = original;
+
       verbose(std::format("Writing {} to border radius {:#x}\n", new_border_radius, reinterpret_cast<ZyanU64>(ptr)));
 
       DWORD old_protect{};

--- a/setup.iss
+++ b/setup.iss
@@ -25,8 +25,8 @@ OutputBaseFilename=win11-toggle-rounded-corners-setup
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
-ArchitecturesAllowed=x64
-ArchitecturesInstallIn64BitMode=x64
+ArchitecturesAllowed=x64os
+ArchitecturesInstallIn64BitMode=x64os
 MissingRunOnceIdsWarning=no
 OutputDir=build
 
@@ -38,14 +38,60 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Source: "LICENSE"; DestDir: "{app}";
 Source: "build\win11-toggle-rounded-corners.exe"; DestDir: "{app}"
 
+[CustomMessages]
+OptionsPageCaption=Rounded Corners Options
+OptionsPageDescription=Choose how you want rounded corners to be handled
+DisableOption=Disable rounded corners completely
+SmallOption=Enable small rounded corners
+
+[Code]
+var
+  OptionsPage: TWizardPage;
+  DisableRadio: TRadioButton;
+  SmallRadio: TRadioButton;
+
+procedure InitializeWizard;
+begin
+  // Create custom options page
+  OptionsPage := CreateCustomPage(wpSelectTasks, 
+    ExpandConstant('{cm:OptionsPageCaption}'), 
+    ExpandConstant('{cm:OptionsPageDescription}'));
+  
+  // Create radio buttons
+  DisableRadio := TRadioButton.Create(OptionsPage);
+  DisableRadio.Parent := OptionsPage.Surface;
+  DisableRadio.Caption := ExpandConstant('{cm:DisableOption}');
+  DisableRadio.Left := 0;
+  DisableRadio.Top := 16;
+  DisableRadio.Width := OptionsPage.SurfaceWidth;
+  DisableRadio.Checked := True; // Default selection
+  
+  SmallRadio := TRadioButton.Create(OptionsPage);
+  SmallRadio.Parent := OptionsPage.Surface;
+  SmallRadio.Caption := ExpandConstant('{cm:SmallOption}');
+  SmallRadio.Left := 0;
+  SmallRadio.Top := 40;
+  SmallRadio.Width := OptionsPage.SurfaceWidth;
+end;
+
+function GetSelectedParameter(Param: String): String;
+begin
+  if DisableRadio.Checked then
+    Result := '--disable'
+  else if SmallRadio.Checked then
+    Result := '--small'
+  else
+    Result := '--disable'; // fallback
+end;
+
 [Run]
 Filename: "schtasks"; \
-  Parameters: "/Create /F /RL highest /SC onlogon /TN ""Run win11-toggle-rounded-corners as admin on logon"" /TR ""'{app}\win11-toggle-rounded-corners.exe' --disable"""; \
+  Parameters: "/Create /F /RL highest /SC onlogon /TN ""Run win11-toggle-rounded-corners as admin on logon"" /TR ""'{app}\win11-toggle-rounded-corners.exe' {code:GetSelectedParameter}"""; \
   Description: "Automatically run on logon"; \
   Flags: runhidden runascurrentuser postinstall
 Filename: "{app}\win11-toggle-rounded-corners.exe"; \
   Description: "Run now"; \
-  Parameters: "--disable"; \
+  Parameters: "{code:GetSelectedParameter}"; \
   Flags: runhidden runascurrentuser nowait postinstall
 
 [UninstallRun]


### PR DESCRIPTION
This PR introduces a new `--small` command-line option that allows users to enable small rounded corners as an alternative to the default rounded corners setting.

Setup now has options to choose small or disabled

![Screenshot 2025-06-17 143802](https://github.com/user-attachments/assets/d3fb527f-6824-4784-aebf-b9eea9e43ce4)

The command line also supports the --small option

![Screenshot 2025-06-17 145224](https://github.com/user-attachments/assets/be4ed086-301b-41a8-a13f-744ed30d81da)

Difference between disabled, small, and normal

![Untitled-1](https://github.com/user-attachments/assets/4ef44430-aae1-497b-b44f-c36e744d3381)